### PR TITLE
fix for container view

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -155,7 +155,11 @@ static inline CGFloat AACStatusBarHeight()
     {
         self.delegateProxy.originalDelegate = _scrollView.delegate;
         _scrollView.delegate = (id)self.delegateProxy;
-    }}
+    }
+    [self cleanup];
+    [self layoutViews];
+    
+}
 
 - (CGRect)extensionViewBounds
 {


### PR DESCRIPTION
When you have n view controllers and one container view and you want to switch between them, but keep one shyNavBar, you can change only scrollview of displayed view controller.
