### PR TITLE
introduce disabled flag

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.h
+++ b/TLYShyNavBar/TLYShyNavBarManager.h
@@ -52,6 +52,8 @@
  */
 @property (nonatomic, getter = isAlphaFadeEnabled) BOOL alphaFadeEnabled;
 
+@property (nonatomic) BOOL disable;
+
 @end
 
 

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -171,10 +171,29 @@ static inline CGFloat AACStatusBarHeight()
     return self.viewController.isViewLoaded && self.viewController.view.window;
 }
 
+- (void)setDisable:(BOOL)disable
+{
+    if (disable == _disable)
+    {
+        return;
+    }
+
+    _disable = disable;
+
+    if (!disable) {
+        self.previousYOffset = self.scrollView.contentOffset.y;
+    }
+}
+
 #pragma mark - Private methods
 
 - (BOOL)_shouldHandleScrolling
 {
+    if (self.disable)
+    {
+        return NO;
+    }
+
     CGRect scrollFrame = UIEdgeInsetsInsetRect(self.scrollView.bounds, self.scrollView.contentInset);
     CGFloat scrollableAmount = self.scrollView.contentSize.height - CGRectGetHeight(scrollFrame);
     BOOL scrollViewIsSuffecientlyLong = (scrollableAmount > self.navBarController.totalHeight);


### PR DESCRIPTION
Issue #43
Also helpful when saving offset then loading new items in table view and finally restoring offset with setContentOffset: method. In this case you better disable shy manager before calling setContentOffset: method and enable it after to preserve navigation bar state.