### PR TITLE
Fixed error caused by inCall status bar height.

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -28,7 +28,7 @@ static inline CGFloat AACStatusBarHeight()
     }
     
     CGSize statusBarSize = [UIApplication sharedApplication].statusBarFrame.size;
-    return MIN(statusBarSize.width, statusBarSize.height);
+    return MIN(MIN(statusBarSize.width, statusBarSize.height), 20.0f);
 }
 
 @implementation UIScrollView(Helper)
@@ -126,7 +126,15 @@ static inline CGFloat AACStatusBarHeight()
         
         self.navBarController.child = self.extensionController;
         
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(applicationDidBecomeActive:)
+                                                     name:UIApplicationDidBecomeActiveNotification
+                                                   object:nil];
+
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(applicationdidChangeStatusBarFrame:)
+                                                     name:UIApplicationDidChangeStatusBarFrameNotification
+                                                   object:nil];
     }
     return self;
 }
@@ -375,8 +383,12 @@ static inline CGFloat AACStatusBarHeight()
 
 #pragma mark - NSNotificationCenter methods
 
-- (void)applicationDidBecomeActive
+- (void)applicationDidBecomeActive:(NSNotification *)notification
 {
+    [self.navBarController expand];
+}
+
+- (void)applicationdidChangeStatusBarFrame:(NSNotification *)notification {
     [self.navBarController expand];
 }
 


### PR DESCRIPTION
Hi @Mazyod 
Here is my hotfix for the issue: https://github.com/telly/TLYShyNavBar/issues/18. 
I couldn't find better way to fix this, maybe it will be helpful for other people too.