### PR TITLE
Fix nav bar position after hiding the extension view

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -362,8 +362,11 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
         
         self.extensionViewContainer.frame = bounds;
         [self.extensionViewContainer addSubview:view];
-        
+
+        BOOL wasDisabled = self.disable;
+        self.disable = YES;
         [self layoutViews];
+        self.disable = wasDisabled;
     }
 }
 

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -363,6 +363,8 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
         self.extensionViewContainer.frame = bounds;
         [self.extensionViewContainer addSubview:view];
 
+        /* Disable scroll handling temporarily while laying out views to avoid double-changing content
+         * offsets in _handleScrolling. */
         BOOL wasDisabled = self.disable;
         self.disable = YES;
         [self layoutViews];


### PR DESCRIPTION
When changing the extension view to nil from it previously being set,appropriate changes are made once... but _handleScrolling is then called, leading to incorrect content offsets until the view is scrolled back to the top.  Disabling scroll handling temporarily while laying out the views fixes the problem.