### PR TITLE
Fix shy nav bar positioning when shown in a popover or modal dialog

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -20,9 +20,13 @@
 // Thanks to SO user, MattDiPasquale
 // http://stackoverflow.com/questions/12991935/how-to-programmatically-get-ios-status-bar-height/16598350#16598350
 
-static inline CGFloat AACStatusBarHeight()
+static inline CGFloat AACStatusBarHeight(UIViewController *viewController)
 {
     if ([UIApplication sharedApplication].statusBarHidden)
+    {
+        return 0.f;
+    }
+    if (viewController.presentingViewController != nil)
     {
         return 0.f;
     }
@@ -96,10 +100,12 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
         
         self.navBarController = [[TLYShyViewController alloc] init];
         self.navBarController.hidesSubviews = YES;
+        __weak __typeof(self) weakSelf = self;
+
         self.navBarController.expandedCenter = ^(UIView *view)
         {
             return CGPointMake(CGRectGetMidX(view.bounds),
-                               CGRectGetMidY(view.bounds) + AACStatusBarHeight());
+                               CGRectGetMidY(view.bounds) + AACStatusBarHeight(weakSelf.viewController));
         };
         
         self.navBarController.contractionAmount = ^(UIView *view)
@@ -119,7 +125,6 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
             return CGRectGetHeight(view.bounds);
         };
         
-        __weak __typeof(self) weakSelf = self;
         self.extensionController.expandedCenter = ^(UIView *view)
         {
             return CGPointMake(CGRectGetMidX(view.bounds),
@@ -290,7 +295,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
 
             deltaY = MIN(0, availableResistance + deltaY);
         }
-        else if (self.scrollView.contentOffset.y > -AACStatusBarHeight())
+        else if (self.scrollView.contentOffset.y > -AACStatusBarHeight(self.viewController))
         {
             CGFloat availableResistance = self.expansionResistance - self.resistanceConsumed;
             self.resistanceConsumed = MIN(self.expansionResistance, self.resistanceConsumed + deltaY);

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -26,8 +26,12 @@ static inline CGFloat AACStatusBarHeight(UIViewController *viewController)
     {
         return 0.f;
     }
-    if (viewController.presentingViewController != nil)
-    {
+    
+    // Modal views do not overlap the status bar, so no allowance need be made for it
+    UIView *view = viewController.view;
+    CGRect frame = [view.superview convertRect:view.frame toView:view.window];
+    BOOL viewOverlapsStatusBar = frame.origin.y < 20.f;
+    if (!viewOverlapsStatusBar) {
         return 0.f;
     }
     

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -110,8 +110,16 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
 
         self.navBarController.expandedCenter = ^(UIView *view)
         {
+            CGFloat statusBarHeight = AACStatusBarHeight(weakSelf.viewController);
+            /* The standard status bar is 20 pixels. The navigation bar extends 20 pixels up so it is overlapped by the status bar.
+             * When there is a larger than 20 pixel status bar (e.g. a phone call is in progress or GPS is active), the center needs
+             * to shift up 20 pixels to avoid this 'dead space' being visible above the usual nav bar.
+             */
+            if (statusBarHeight > 20)
+                statusBarHeight -= 20;
+
             return CGPointMake(CGRectGetMidX(view.bounds),
-                               CGRectGetMidY(view.bounds) + AACStatusBarHeight(weakSelf.viewController));
+                               CGRectGetMidY(view.bounds) + statusBarHeight);
         };
         
         self.navBarController.contractionAmount = ^(UIView *view)

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -28,15 +28,17 @@ static inline CGFloat AACStatusBarHeight(UIViewController *viewController)
     }
     
     // Modal views do not overlap the status bar, so no allowance need be made for it
+    CGSize  statusBarSize = [UIApplication sharedApplication].statusBarFrame.size;
+    CGFloat statusBarHeight = MIN(statusBarSize.width, statusBarSize.height);
+    
     UIView *view = viewController.view;
     CGRect frame = [view.superview convertRect:view.frame toView:view.window];
-    BOOL viewOverlapsStatusBar = frame.origin.y < 20.f;
+    BOOL viewOverlapsStatusBar = frame.origin.y < statusBarHeight;
     if (!viewOverlapsStatusBar) {
         return 0.f;
     }
     
-    CGSize statusBarSize = [UIApplication sharedApplication].statusBarFrame.size;
-    return MIN(MIN(statusBarSize.width, statusBarSize.height), 20.0f);
+    return statusBarHeight;
 }
 
 static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManagerKVOContext;


### PR DESCRIPTION
If the viewController is within a popover or other modal view, it should not be placed a status bar height below the top of that view.  This fixes the use of shyNavBars in those settings.