### PR TITLE
Fix scrollToTop (by tapping on the status bar)

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -413,6 +413,12 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
     }
 }
 
+- (void)scrollViewDidScrollToTop:(UIScrollView *)scrollView
+{
+    [self.scrollView scrollRectToVisible:CGRectMake(0,0,1,1) animated:YES];
+    [self.scrollView flashScrollIndicators];
+}
+
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
 {
     [self _handleScrollingEnded];


### PR DESCRIPTION
If the status bar is tapped to scroll to the top, the system doesn't understand the presence of the hidden nav bar or optional extension view.  Therefore, once scrolling is deemed complete, we need to scroll up a bit further.  I played extensively with doing this all in one go, for example by overriding the behavior in scrollViewShouldScrollToTop, but couldn't make it work smoothly. 

This implementation does have a small stutter as the larger first animation transitions into the second smaller animation occurs, but it is much better than before.