### PR TITLE
Added ability to alphaFade entire navbar and transfer userInteractionEnabled state to extension view container

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.h
+++ b/TLYShyNavBar/TLYShyNavBarManager.h
@@ -56,6 +56,7 @@
  * Defaults to YES
  */
 @property (nonatomic, getter = isAlphaFadeEnabled) BOOL alphaFadeEnabled;
+@property (nonatomic, getter = isAlphaFadeEntireNavBarEnabled) BOOL alphaFadeEntireNavBar;
 
 @property (nonatomic) BOOL disable;
 

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -100,6 +100,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
         self.contractionResistance = 0.f;
         
         self.alphaFadeEnabled = YES;
+        self.alphaFadeEntireNavBar = NO;
         
         self.previousScrollInsets = UIEdgeInsetsZero;
         self.previousYOffset = NAN;
@@ -320,6 +321,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
         
         // 6 - Update the shyViewController
         self.navBarController.alphaFadeEnabled = self.alphaFadeEnabled;
+        self.navBarController.alphaFadeEntireNavBar = self.alphaFadeEntireNavBar;
         [self.navBarController updateYOffset:deltaY];
     }
     
@@ -382,6 +384,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
         
         self.extensionViewContainer.frame = bounds;
         [self.extensionViewContainer addSubview:view];
+        self.extensionViewContainer.userInteractionEnabled = view.userInteractionEnabled;
 
         /* Disable scroll handling temporarily while laying out views to avoid double-changing content
          * offsets in _handleScrolling. */

--- a/TLYShyNavBar/TLYShyViewController.h
+++ b/TLYShyNavBar/TLYShyViewController.h
@@ -37,6 +37,7 @@ typedef CGFloat(^TLYShyViewControllerContractionAmountBlock)(UIView *view);
 @property (nonatomic) BOOL hidesAfterContraction;
 
 @property (nonatomic) BOOL alphaFadeEnabled;
+@property (nonatomic) BOOL alphaFadeEntireNavBar;
 
 @property (nonatomic, readonly) CGFloat totalHeight;
 

--- a/TLYShyNavBar/TLYShyViewController.m
+++ b/TLYShyNavBar/TLYShyViewController.m
@@ -61,8 +61,12 @@ const CGFloat contractionVelocity = 300.f;
 
 // This method is courtesy of GTScrollNavigationBar
 // https://github.com/luugiathuy/GTScrollNavigationBar
-- (void)_updateSubviewsToAlpha:(CGFloat)alpha
+- (void)_updateViewsToAlpha:(CGFloat)alpha
 {
+    if (_alphaFadeEntireNavBar) {
+        self.view.alpha = alpha;
+    }
+
     for (UIView* view in self.view.subviews)
     {
         bool isBackgroundView = view == self.view.subviews[0];
@@ -83,7 +87,7 @@ const CGFloat contractionVelocity = 300.f;
     
     if (!alphaFadeEnabled)
     {
-        [self _updateSubviewsToAlpha:1.f];
+        [self _updateViewsToAlpha:1.f];
     }
 }
 
@@ -113,7 +117,7 @@ const CGFloat contractionVelocity = 300.f;
         
         if (self.alphaFadeEnabled)
         {
-            [self _updateSubviewsToAlpha:newAlpha];
+            [self _updateViewsToAlpha:newAlpha];
         }
     }
     
@@ -163,7 +167,7 @@ const CGFloat contractionVelocity = 300.f;
     
     if (self.hidesSubviews && self.alphaFadeEnabled)
     {
-        [self _updateSubviewsToAlpha:1.f];
+        [self _updateViewsToAlpha:1.f];
     }
     
     CGFloat amountToMove = self.expandedCenterValue.y - self.view.center.y;


### PR DESCRIPTION
These two modifications are very specific to our usage of TlyShyNavBar but I feel like they could be generalized enough for other people to use them. 

1) We need the entire nav bar to alphaFade, not just it’s subviews. We do not need the nav bar to stay behind the status bar and this addition simply hides everything as the user scrolls.

2) We are using the extension view as a transparent overlay and need the view below it to capture any touches. If the users sets the userInteractionDisabled property on the extensionView this will be transferred to the container view managed by the nav bar view controller, essentially disabling all user interaction in the extension view.