### PR TITLE
FIx include paths in TLYShyNavBarManager

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -10,8 +10,8 @@
 #import "TLYShyViewController.h"
 #import "TLYDelegateProxy.h"
 
-#import "UIViewController+BetterLayoutGuides.h"
-#import "NSObject+TLYSwizzlingHelpers.h"
+#import "Categories/UIViewController+BetterLayoutGuides.h"
+#import "Categories/NSObject+TLYSwizzlingHelpers.h"
 
 #import <objc/runtime.h>
 


### PR DESCRIPTION
This fixes some include paths to make the code build even without headermaps. My build configuration doesn't use it, so the code won't build unless the include paths are exactly right.