### PR TITLE
Navbar expanding

### DIFF
--- a/TLYShyNavBar/ShyControllers/TLYShyViewController.h
+++ b/TLYShyNavBar/ShyControllers/TLYShyViewController.h
@@ -36,7 +36,7 @@ typedef CGFloat(^TLYShyViewControllerContractionAmountBlock)(UIView *view);
 @property (nonatomic, weak) id<TLYShyParent> parent;
 @property (nonatomic, weak) TLYShyViewController *subShyController;
 @property (nonatomic, weak) UIView *view;
-
+@property (nonatomic, readonly, assign) BOOL isContracted;
 @property (nonatomic) TLYShyNavBarFade fadeBehavior;
 
 /* Sticky means it will always stay in expanded state

--- a/TLYShyNavBar/ShyControllers/TLYShyViewController.h
+++ b/TLYShyNavBar/ShyControllers/TLYShyViewController.h
@@ -47,7 +47,9 @@ typedef CGFloat(^TLYShyViewControllerContractionAmountBlock)(UIView *view);
 - (CGFloat)updateYOffset:(CGFloat)deltaY;
 
 - (CGFloat)snap:(BOOL)contract;
-- (CGFloat)snap:(BOOL)contract completion:(void (^)())completion;
+
+
+- (CGFloat)snap:(BOOL)contract offset:(void (^)(CGFloat deltaY))offset completion:(void (^)())completion;
 
 - (CGFloat)expand;
 - (CGFloat)contract;

--- a/TLYShyNavBar/ShyControllers/TLYShyViewController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyViewController.m
@@ -14,6 +14,10 @@
 - (CGFloat)maxYRelativeToView:(UIView *)superview
 {
     CGPoint maxEdge = CGPointMake(0, CGRectGetHeight(self.view.bounds));
+    if ([self.view isKindOfClass:[UINavigationBar class]]){
+        return maxEdge.y + self.view.frame.origin.y;
+    }
+    
     CGPoint normalizedMaxEdge = [superview convertPoint:maxEdge fromView:self.view];
     
     return normalizedMaxEdge.y;

--- a/TLYShyNavBar/ShyControllers/TLYShyViewController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyViewController.m
@@ -189,10 +189,10 @@
 
 - (CGFloat)snap:(BOOL)contract
 {
-    return [self snap:contract completion:nil];
+    return [self snap:contract offset:nil completion:nil];
 }
 
-- (CGFloat)snap:(BOOL)contract completion:(void (^)())completion
+- (CGFloat)snap:(BOOL)contract offset:(void (^)(CGFloat deltaY))offset completion:(void (^)())completion
 {
     /* "The Facebook" UX dictates that:
      *
@@ -215,9 +215,14 @@
         else
         {
             deltaY = [self.subShyController expand];
+            if (offset) {
+                offset(deltaY);
+            }
         }
+       
+
     }
-                     completion:^(BOOL finished)
+    completion:^(BOOL finished)
     {
         if (completion && finished) {
             completion();

--- a/TLYShyNavBar/ShyControllers/TLYShyViewController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyViewController.m
@@ -37,16 +37,21 @@
 @property (nonatomic, assign) CGFloat contractionAmountValue;
 
 @property (nonatomic, assign) CGPoint contractedCenterValue;
-
-@property (nonatomic, assign) BOOL contracted;
-@property (nonatomic, assign) BOOL expanded;
+@property (nonatomic, readwrite, assign) BOOL isContracted;
 
 @end
 
 @implementation TLYShyViewController
 
 #pragma mark - Properties
-
+- (id) init
+{
+    self = [super init];
+    if (self){
+        self.isContracted = YES;
+    }
+    return self;
+}
 // convenience
 - (CGPoint)expandedCenterValue
 {
@@ -245,8 +250,8 @@
     CGFloat amountToMove = self.expandedCenterValue.y - self.view.center.y;
 
     [self _updateCenter:self.expandedCenterValue];
-    [self.subShyController expand];
-    
+    amountToMove += [self.subShyController expand];
+    self.isContracted = NO;
     return amountToMove;
 }
 
@@ -257,8 +262,8 @@
     [self _onAlphaUpdate:FLT_EPSILON];
 
     [self _updateCenter:self.contractedCenterValue];
-    [self.subShyController contract];
-    
+    amountToMove += [self.subShyController contract];
+    self.isContracted = YES;
     return amountToMove;
 }
 

--- a/TLYShyNavBar/ShyControllers/TLYShyViewController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyViewController.m
@@ -159,7 +159,7 @@
 }
 
 - (CGFloat)updateYOffset:(CGFloat)deltaY
-{    
+{
     if (self.subShyController && deltaY < 0)
     {
         deltaY = [self.subShyController updateYOffset:deltaY];
@@ -216,27 +216,28 @@
     
     __block CGFloat deltaY;
     [UIView animateWithDuration:0.2 animations:^
-    {
-        if ((contract && self.subShyController.contracted) || (!contract && !self.expanded))
-        {
-            deltaY = [self contract];
-        }
-        else
-        {
-            deltaY = [self.subShyController expand];
-            if (offset) {
-                offset(deltaY);
-            }
-        }
-       
-
-    }
-    completion:^(BOOL finished)
-    {
-        if (completion && finished) {
-            completion();
-        }
-    }];
+     {
+         if ((contract && self.subShyController.contracted) || (!contract && !self.expanded))
+         {
+             deltaY = [self contract];
+         }
+         else
+         {
+             deltaY = [self.subShyController expand];
+         }
+         //Shift scrollView by delta like Facebook does.
+         if (offset && fabs(deltaY) < FLT_EPSILON) {
+             offset(deltaY);
+         }
+         
+         
+     }
+                     completion:^(BOOL finished)
+     {
+         if (completion && finished) {
+             completion();
+         }
+     }];
     
     return deltaY;
 }
@@ -248,7 +249,7 @@
     [self _onAlphaUpdate:1.f];
     
     CGFloat amountToMove = self.expandedCenterValue.y - self.view.center.y;
-
+    
     [self _updateCenter:self.expandedCenterValue];
     amountToMove += [self.subShyController expand];
     self.isContracted = NO;
@@ -258,9 +259,9 @@
 - (CGFloat)contract
 {
     CGFloat amountToMove = self.contractedCenterValue.y - self.view.center.y;
-
+    
     [self _onAlphaUpdate:FLT_EPSILON];
-
+    
     [self _updateCenter:self.contractedCenterValue];
     amountToMove += [self.subShyController contract];
     self.isContracted = YES;

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -319,8 +319,8 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
         return;
     }
 
-    __weak __typeof(self) weakSelf;
-    void (^completion)() = ^
+    __weak __typeof(self) weakSelf = self;
+    void (^completion)() = ^()
     {
         __typeof(self) strongSelf = weakSelf;
         if (strongSelf) {
@@ -336,8 +336,18 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
         }
     };
 
+    
+    void (^offset)(CGFloat deltaY) = ^(CGFloat deltaY)
+    {
+        __typeof(self) strongSelf = weakSelf;
+        if (strongSelf) {
+            [strongSelf.scrollView setContentOffset:CGPointMake(0, strongSelf.scrollView.contentOffset.y - deltaY)];
+        }
+    };
+
+    
     self.resistanceConsumed = 0;
-    [self.navBarController snap:self.contracting completion:completion];
+    [self.navBarController snap:self.contracting offset:offset completion:completion];
 }
 
 #pragma mark - KVO

--- a/TLYShyNavBarDemo/TLYShyNavBarDemo/Base.lproj/Main.storyboard
+++ b/TLYShyNavBarDemo/TLYShyNavBarDemo/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="7bU-2Z-BIA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="7bU-2Z-BIA">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -77,14 +77,14 @@
                                 <rect key="frame" x="0.0" y="86" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="RGY-hR-OFV" id="XWF-ra-5eA">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="General Test" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="aqG-vx-7ht">
-                                            <rect key="frame" x="15" y="0.0" width="270" height="43.5"/>
+                                            <rect key="frame" x="15" y="0.0" width="270" height="43"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -97,14 +97,14 @@
                                 <rect key="frame" x="0.0" y="130" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dRT-27-ySW" id="cDy-Ba-zBy">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="No Extension View Test" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2GL-4f-xic">
-                                            <rect key="frame" x="15" y="0.0" width="270" height="43.5"/>
+                                            <rect key="frame" x="15" y="0.0" width="270" height="43"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -117,14 +117,14 @@
                                 <rect key="frame" x="0.0" y="174" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="TTx-eK-xUp" id="N2A-N5-eQc">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Sticky Extension Test" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="WdW-Lh-Cfs">
-                                            <rect key="frame" x="15" y="0.0" width="270" height="43.5"/>
+                                            <rect key="frame" x="15" y="0.0" width="270" height="43"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -137,14 +137,14 @@
                                 <rect key="frame" x="0.0" y="218" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="0y3-Aj-VEQ" id="w1B-en-E0m">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Sticky Navbar Test" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="WIt-Sx-VLk">
-                                            <rect key="frame" x="15" y="0.0" width="270" height="43.5"/>
+                                            <rect key="frame" x="15" y="0.0" width="270" height="43"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -157,14 +157,14 @@
                                 <rect key="frame" x="0.0" y="262" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="CJy-qF-mnS" id="nYc-co-8cU">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Fade Navbar Test" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7pe-uQ-9XE">
-                                            <rect key="frame" x="15" y="0.0" width="270" height="43.5"/>
+                                            <rect key="frame" x="15" y="0.0" width="270" height="43"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -177,14 +177,14 @@
                                 <rect key="frame" x="0.0" y="306" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cog-xO-RM8" id="bqe-Oi-QQK">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Test UITableView" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qz8-f8-ztz">
-                                            <rect key="frame" x="15" y="0.0" width="270" height="43.5"/>
+                                            <rect key="frame" x="15" y="0.0" width="270" height="43"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -197,14 +197,14 @@
                                 <rect key="frame" x="0.0" y="350" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lDx-31-RTM" id="Pch-9t-ngw">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Test UICollectionView" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="JCj-eZ-ePK">
-                                            <rect key="frame" x="15" y="0.0" width="270" height="43.5"/>
+                                            <rect key="frame" x="15" y="0.0" width="270" height="43"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -217,14 +217,14 @@
                                 <rect key="frame" x="0.0" y="394" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="iMg-k0-Aaw" id="5e1-WH-Lge">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Test Short ScrollView" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="CgM-Go-0Tl">
-                                            <rect key="frame" x="15" y="0.0" width="270" height="43.5"/>
+                                            <rect key="frame" x="15" y="0.0" width="270" height="43"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -353,7 +353,7 @@
                                         <label opaque="NO" userInteractionEnabled="NO" tag="777" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Vf-lE-VWT">
                                             <rect key="frame" x="8" y="14" width="42" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -396,7 +396,7 @@
                                         <rect key="frame" x="0.0" y="92" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NX5-B0-7pf" id="ITe-rA-1zD">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -628,7 +628,7 @@
                                         <rect key="frame" x="0.0" y="92" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="jHM-wp-EHl" id="mGW-Ao-Srl">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>


### PR DESCRIPTION
Hello,

Thank you for so beautiful library. It helped me a lot, but there are a few bug and behaviour inconsistencies:

1. [Bug] extensionView is placed incorrectly after popping detalis from navigationController stack as long as you change navigationBar visibility during view's transiotion.

I'm hiding/showing navigation bar via setNavigationBarHidden when pushing/poping details vew. And at that moment line:

`[superview convertPoint:maxEdge fromView:self.view]`
is working incorrectly.

So I've replaced it gently.
2. Facebok's Navbar shifts it's scrollview on expanding/contracting completion. I've implemented that. 
3. Facebook's Navbar shifts it's scrollview on expanding after view's shown. I've implemented that.

Also there was strange code that created weak pointer without assignation:
`__weak __typeof(self) weakSelf;`
I've changed it by:
`__weak __typeof(self) weakSelf = self;`

Maybe I miss something in objective-c?


Hope my changes will help you a bit.

Regards,
Peter  
