### PR TITLE
Scroll view started with wrong content offset on some occasions

### DIFF
--- a/TLYShyNavBar/Categories/UIScrollView+Helpers.h
+++ b/TLYShyNavBar/Categories/UIScrollView+Helpers.h
@@ -11,6 +11,6 @@
 
 @interface UIScrollView (Helpers)
 
-- (void)tly_setInsets:(UIEdgeInsets)contentInsets preserveOffset:(BOOL)preserveOffset;
+- (void)tly_setInsets:(UIEdgeInsets)contentInsets;
 
 @end

--- a/TLYShyNavBar/Categories/UIScrollView+Helpers.m
+++ b/TLYShyNavBar/Categories/UIScrollView+Helpers.m
@@ -11,9 +11,9 @@
 @implementation UIScrollView (Helpers)
 
 // Modify contentInset and scrollIndicatorInsets
-- (void)tly_setInsets:(UIEdgeInsets)contentInsets preserveOffset:(BOOL)preserveOffset
+- (void)tly_setInsets:(UIEdgeInsets)contentInsets
 {
-    if (preserveOffset && contentInsets.top != self.contentInset.top)
+    if (!self.isDragging && !self.isDecelerating && contentInsets.top != self.contentInset.top)
     {
         CGFloat offsetDelta = contentInsets.top - self.contentInset.top;
         

--- a/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.h
+++ b/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.h
@@ -17,6 +17,6 @@
 @property (nonatomic, weak) UIScrollView *scrollView;
 @property (nonatomic, weak) TLYShyViewController *parent;
 
-- (CGFloat)updateLayoutIfNeeded:(BOOL)intelligently;
+- (CGFloat)updateLayoutIfNeeded;
 
 @end

--- a/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.m
@@ -14,10 +14,10 @@
 
 - (void)offsetCenterBy:(CGPoint)deltaPoint
 {
-    [self updateLayoutIfNeeded:NO];
+    [self updateLayoutIfNeeded];
 }
 
-- (CGFloat)updateLayoutIfNeeded:(BOOL)intelligently
+- (CGFloat)updateLayoutIfNeeded
 {
     if (self.scrollView.contentSize.height < FLT_EPSILON
         && ([self.scrollView isKindOfClass:[UITableView class]]
@@ -35,7 +35,7 @@
     if (normalizedY > -FLT_EPSILON && !UIEdgeInsetsEqualToEdgeInsets(insets, self.scrollView.contentInset))
     {
         CGFloat delta = insets.top - self.scrollView.contentInset.top;
-        [self.scrollView tly_setInsets:insets preserveOffset:intelligently];
+        [self.scrollView tly_setInsets:insets];
         
         return delta;
     }
@@ -46,7 +46,7 @@
         frame = UIEdgeInsetsInsetRect(frame, insets);
         
         self.scrollView.frame = frame;
-        return [self updateLayoutIfNeeded:YES];
+        return [self updateLayoutIfNeeded];
     }
     
     return 0.f;

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -394,7 +394,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
 
 - (void)layoutViews
 {
-    if (fabs([self.scrollViewController updateLayoutIfNeeded:YES]) > FLT_EPSILON)
+    if (fabs([self.scrollViewController updateLayoutIfNeeded]) > FLT_EPSILON)
     {
         [self.navBarController expand];
         [self.extensionViewContainer.superview bringSubviewToFront:self.extensionViewContainer];


### PR DESCRIPTION
Hey there, I was having an issue on a project I'm working on using this library. The issue was that a table view was being displayed with the wrong `contentOffset` when first loaded. The `contentInset` was fine though. In my particular case, the contentInset was 108 (20 status bar + 44 nav bar + 44 custom extension view). But after the `contentInset` was set by this library, the `contentOffset` was still using a previous value. I don't exactly know why this happened now (this didn't happened before), but the changes I'm sending fixes the issue.

Basically, if by the time the `contentInset` was being set in the beginning the `preserveOffset` flag would have been `YES`, then the `contentOffset` property would have been updated correctly. However, forcing this to `YES` caused that when scrolling, the `contentOffset` was being modified as well, causing the amount of points to be scrolled to double.

What I did to correct this was to remove this flag and rely on some flags about the scroll view itself.

Does this look good to you? Any thoughts about this PR? Thanks for this awesome library!