### PR TITLE
Added method to query if a TLYShyNavBarManager instance is associated with a UIViewController without triggering its creation

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.h
+++ b/TLYShyNavBar/TLYShyNavBarManager.h
@@ -110,4 +110,9 @@
 /* Initially, this is nil, but created for you when you access it */
 @property (nonatomic, strong) TLYShyNavBarManager *shyNavBarManager;
 
+/* Use this to find out if a TLYShyNavBarManager instance was associated
+ * to this view controller, without triggering its creation and association.
+ */
+- (BOOL)isShyNavBarManagerPresent;
+
 @end

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -485,6 +485,13 @@ static char shyNavBarManagerKey;
     [self tly_swizzledViewWillDisappear:animated];
 }
 
+#pragma mark - Public methods
+
+- (BOOL)isShyNavBarManagerPresent
+{
+    return [self _internalShyNavBarManager] != nil;
+}
+
 #pragma mark - Properties
 
 - (void)setShyNavBarManager:(TLYShyNavBarManager *)shyNavBarManager


### PR DESCRIPTION
I think the title is self explanatory, this is another need I had on my project.