### PR TITLE
Allow specific view controller to be set if needed

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.h
+++ b/TLYShyNavBar/TLYShyNavBarManager.h
@@ -110,6 +110,12 @@
 /* Initially, this is nil, but created for you when you access it */
 @property (nonatomic, strong) TLYShyNavBarManager *shyNavBarManager;
 
+/*
+ * Set the TLYShyNavBarManager while also specifying a view controller
+ */
+- (void)setShyNavBarManager:(TLYShyNavBarManager *)shyNavBarManager
+             viewController:(UIViewController *)viewController;
+
 /* Use this to find out if a TLYShyNavBarManager instance was associated
  * to this view controller, without triggering its creation and association.
  */

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -492,12 +492,19 @@ static char shyNavBarManagerKey;
     return [self _internalShyNavBarManager] != nil;
 }
 
+- (void)setShyNavBarManager:(TLYShyNavBarManager *)shyNavBarManager
+             viewController:(UIViewController *)viewController
+{
+    NSAssert(viewController != nil, @"viewController must not be nil!");
+    shyNavBarManager.viewController = viewController;
+    objc_setAssociatedObject(self, &shyNavBarManagerKey, shyNavBarManager, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 #pragma mark - Properties
 
 - (void)setShyNavBarManager:(TLYShyNavBarManager *)shyNavBarManager
 {
-    shyNavBarManager.viewController = self;
-    objc_setAssociatedObject(self, &shyNavBarManagerKey, shyNavBarManager, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [self setShyNavBarManager:shyNavBarManager viewController:self];
 }
 
 - (TLYShyNavBarManager *)shyNavBarManager


### PR DESCRIPTION
In the case where `self` is not the correct viewController to use for the navigation control you can now set a specific viewController using the new method.

## Use case

A UINavigationController with a UITabBarController in it.  We need to set the scrollView equal to the UIViewController's UITableView, but the ViewController needs to be the TabBarController.