### PR TITLE
Fix refresh

### DIFF
--- a/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.h
+++ b/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.h
@@ -15,6 +15,7 @@
 @interface TLYShyScrollViewController : NSObject <TLYShyChild>
 
 @property (nonatomic, weak) UIScrollView *scrollView;
+@property (nonatomic, weak) UIRefreshControl *refreshControl;
 @property (nonatomic, weak) TLYShyViewController *parent;
 
 - (CGFloat)updateLayoutIfNeeded;

--- a/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.m
@@ -20,18 +20,18 @@
 - (CGFloat)updateLayoutIfNeeded
 {
     if (self.scrollView.contentSize.height < FLT_EPSILON
-         && ([self.scrollView isKindOfClass:[UITableView class]]
-             || [self.scrollView isKindOfClass:[UICollectionView class]])
-         )
+        && ([self.scrollView isKindOfClass:[UITableView class]]
+            || [self.scrollView isKindOfClass:[UICollectionView class]])
+        )
     {
         return 0.f;
     }
-    
+
     CGFloat parentMaxY = [self.parent maxYRelativeToView:self.scrollView.superview];
     CGFloat normalizedY = parentMaxY - self.scrollView.frame.origin.y;
     UIEdgeInsets insets = UIEdgeInsetsMake(self.scrollView.contentInset.top, 0, self.scrollView.contentInset.bottom, 0);
     insets.top = normalizedY;
-    
+
     if (normalizedY > -FLT_EPSILON && !UIEdgeInsetsEqualToEdgeInsets(insets, self.scrollView.contentInset))
     {
         CGFloat delta = insets.top - self.scrollView.contentInset.top;
@@ -39,19 +39,19 @@
         if (self.refreshControl == nil || [self.refreshControl isHidden]) {
             [self.scrollView tly_setInsets:insets];
         }
-        
+
         return delta;
     }
-    
+
     if (normalizedY < -FLT_EPSILON)
-    {        
+    {
         CGRect frame = self.scrollView.frame;
         frame = UIEdgeInsetsInsetRect(frame, insets);
-        
+
         self.scrollView.frame = frame;
         return [self updateLayoutIfNeeded];
     }
-    
+
     return 0.f;
 }
 

--- a/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.m
@@ -19,10 +19,10 @@
 
 - (CGFloat)updateLayoutIfNeeded
 {
-    if ((self.scrollView.contentSize.height < FLT_EPSILON
+    if (self.scrollView.contentSize.height < FLT_EPSILON
          && ([self.scrollView isKindOfClass:[UITableView class]]
              || [self.scrollView isKindOfClass:[UICollectionView class]])
-         ) || (self.scrollView.contentOffset.y <= -64))
+         )
     {
         return 0.f;
     }
@@ -35,7 +35,10 @@
     if (normalizedY > -FLT_EPSILON && !UIEdgeInsetsEqualToEdgeInsets(insets, self.scrollView.contentInset))
     {
         CGFloat delta = insets.top - self.scrollView.contentInset.top;
-        [self.scrollView tly_setInsets:insets];
+
+        if (self.refreshControl == nil || [self.refreshControl isHidden]) {
+            [self.scrollView tly_setInsets:insets];
+        }
         
         return delta;
     }

--- a/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.m
@@ -19,10 +19,10 @@
 
 - (CGFloat)updateLayoutIfNeeded
 {
-    if (self.scrollView.contentSize.height < FLT_EPSILON
-        && ([self.scrollView isKindOfClass:[UITableView class]]
-            || [self.scrollView isKindOfClass:[UICollectionView class]])
-        )
+    if ((self.scrollView.contentSize.height < FLT_EPSILON
+         && ([self.scrollView isKindOfClass:[UITableView class]]
+             || [self.scrollView isKindOfClass:[UICollectionView class]])
+         ) || (self.scrollView.contentOffset.y <= -64))
     {
         return 0.f;
     }

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -155,7 +155,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
     NSUInteger index = [scrollView.subviews indexOfObjectPassingTest:^BOOL (id obj, NSUInteger idx, BOOL *stop) {
         return [obj isKindOfClass:[UIRefreshControl class]];
     }];
-    
+
     if (index != NSNotFound) {
         self.scrollViewController.refreshControl = [scrollView.subviews objectAtIndex:index];
     }

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -155,6 +155,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
     NSUInteger index = [scrollView.subviews indexOfObjectPassingTest:^BOOL (id obj, NSUInteger idx, BOOL *stop) {
         return [obj isKindOfClass:[UIRefreshControl class]];
     }];
+    
     if (index != NSNotFound) {
         self.scrollViewController.refreshControl = [scrollView.subviews objectAtIndex:index];
     }

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -152,6 +152,13 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
     _scrollView = scrollView;
     self.scrollViewController.scrollView = scrollView;
 
+    NSUInteger index = [scrollView.subviews indexOfObjectPassingTest:^BOOL (id obj, NSUInteger idx, BOOL *stop) {
+        return [obj isKindOfClass:[UIRefreshControl class]];
+    }];
+    if (index != NSNotFound) {
+        self.scrollViewController.refreshControl = [scrollView.subviews objectAtIndex:index];
+    }
+
     if (_scrollView.delegate != self.delegateProxy)
     {
         self.delegateProxy.originalDelegate = _scrollView.delegate;


### PR DESCRIPTION
I believe this could be a clean fix for the refresh control issue found here: https://github.com/telly/TLYShyNavBar/issues/99

## What it does

This checks to see if any of the subviews of the scrollview being set is of type UIRefreshControl.  If it is it sets a new property on the shyscrollviewcontroller equal to that refresh control.  If the refreshControl is nil (a scrollview without pull to refresh) the code behaves the same (still calling tly_setInsets), if the refreshControl exists it only calls tly_setInsets if the refreshControl is hidden. I tried to check if the refreshControl was refreshing but that check is too late.  This PR will make it so when the pull to refresh appears (user is thinking about refreshing) we will no longer layout the views.  It seems to work on my end.