### PR TITLE
Fix jumping

### DIFF
--- a/TLYShyNavBar/Categories/UIScrollView+Helpers.m
+++ b/TLYShyNavBar/Categories/UIScrollView+Helpers.m
@@ -12,16 +12,7 @@
 
 // Modify contentInset and scrollIndicatorInsets
 - (void)tly_setInsets:(UIEdgeInsets)contentInsets
-{
-    if (!self.isDragging && !self.isDecelerating && contentInsets.top != self.contentInset.top)
-    {
-        CGFloat offsetDelta = contentInsets.top - self.contentInset.top;
-        
-        CGRect bounds = self.bounds;
-        bounds.origin.y -= offsetDelta;
-        self.bounds = bounds;
-    }
-    
+{    
     self.contentInset = contentInsets;
     self.scrollIndicatorInsets = contentInsets;
 }

--- a/TLYShyNavBar/Categories/UIScrollView+Helpers.m
+++ b/TLYShyNavBar/Categories/UIScrollView+Helpers.m
@@ -12,7 +12,7 @@
 
 // Modify contentInset and scrollIndicatorInsets
 - (void)tly_setInsets:(UIEdgeInsets)contentInsets
-{    
+{
     self.contentInset = contentInsets;
     self.scrollIndicatorInsets = contentInsets;
 }


### PR DESCRIPTION
If I pushed a view onto the navigation stack and popped back to the table view it would have the incorrect offset and need to scroll to adjust correctly.  Removing the bounds change didn't seem to negatively effect anything and fixed my issue.  I'm not 100% sure about all cases here but thought a PR to look at would at the very least be interesting.