### PR TITLE
Ability to use custom pull to refresh controls

### DIFF
--- a/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.h
+++ b/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.h
@@ -18,7 +18,7 @@
 @property (nonatomic, weak) UIRefreshControl *refreshControl;
 @property (nonatomic, weak) TLYShyViewController *parent;
 
-@property (nonatomic, assign) BOOL hasCustomRefreshController;
+@property (nonatomic, assign) BOOL hasCustomRefreshControl;
 
 - (CGFloat)updateLayoutIfNeeded;
 

--- a/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.h
+++ b/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.h
@@ -18,6 +18,8 @@
 @property (nonatomic, weak) UIRefreshControl *refreshControl;
 @property (nonatomic, weak) TLYShyViewController *parent;
 
+@property (nonatomic, assign) BOOL hasCustomRefreshController;
+
 - (CGFloat)updateLayoutIfNeeded;
 
 @end

--- a/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.m
@@ -36,7 +36,7 @@
     {
         CGFloat delta = insets.top - self.scrollView.contentInset.top;
 
-        if (self.refreshControl == nil || [self.refreshControl isHidden]) {
+        if (!self.hasCustomRefreshController && (self.refreshControl == nil || [self.refreshControl isHidden])) {
             [self.scrollView tly_setInsets:insets];
         }
 

--- a/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyScrollViewController.m
@@ -36,7 +36,7 @@
     {
         CGFloat delta = insets.top - self.scrollView.contentInset.top;
 
-        if (!self.hasCustomRefreshController && (self.refreshControl == nil || [self.refreshControl isHidden])) {
+        if (!self.hasCustomRefreshControl && (self.refreshControl == nil || [self.refreshControl isHidden])) {
             [self.scrollView tly_setInsets:insets];
         }
 

--- a/TLYShyNavBar/TLYShyNavBarManager.h
+++ b/TLYShyNavBar/TLYShyNavBarManager.h
@@ -67,10 +67,9 @@
  */
 @property (nonatomic) TLYShyNavBarFade fadeBehavior;
 
-/* Use this to set if the controller have any kind of refresh controller
- * other than UIRefreshController (this one will be identified automatically)
+/* Use this to set if the controller have any kind of custom refresh control
  */
-@property (nonatomic) BOOL hasCustomRefreshController;
+@property (nonatomic) BOOL hasCustomRefreshControl;
 
 /* Set NO to disable shyNavBar behavior temporarily.
  * Defaults to NO

--- a/TLYShyNavBar/TLYShyNavBarManager.h
+++ b/TLYShyNavBar/TLYShyNavBarManager.h
@@ -67,6 +67,11 @@
  */
 @property (nonatomic) TLYShyNavBarFade fadeBehavior;
 
+/* Use this to set if the controller have any kind of refresh controller
+ * other than UIRefreshController (this one will be identified automatically)
+ */
+@property (nonatomic) BOOL hasCustomRefreshController;
+
 /* Set NO to disable shyNavBar behavior temporarily.
  * Defaults to NO
  */

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -112,7 +112,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
     }
 
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [self removeKVOObserver];
+    [_scrollView removeObserver:self forKeyPath:@"contentSize" context:kTLYShyNavBarManagerKVOContext];
 }
 
 #pragma mark - Properties
@@ -142,7 +142,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
 
 - (void)setScrollView:(UIScrollView *)scrollView
 {
-    [self removeKVOObserver];
+    [_scrollView removeObserver:self forKeyPath:@"contentSize" context:kTLYShyNavBarManagerKVOContext];
 
     if (_scrollView.delegate == self.delegateProxy)
     {
@@ -169,7 +169,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
     [self cleanup];
     [self layoutViews];
 
-    [self addKVOObserver];
+    [_scrollView addObserver:self forKeyPath:@"contentSize" options:0 context:kTLYShyNavBarManagerKVOContext];
 }
 
 - (CGRect)extensionViewBounds
@@ -194,6 +194,18 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
     if (!disable) {
         self.previousYOffset = self.scrollView.contentOffset.y;
     }
+}
+
+- (void)setHasCustomRefreshController:(BOOL)hasCustomRefreshController
+{
+    if (_hasCustomRefreshController == hasCustomRefreshController)
+    {
+        return;
+    }
+    
+    _hasCustomRefreshController = hasCustomRefreshController;
+    
+    self.scrollViewController.hasCustomRefreshController = hasCustomRefreshController;
 }
 
 - (BOOL)stickyNavigationBar
@@ -359,25 +371,13 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
     {
         if (self.isViewControllerVisible && ![self _scrollViewIsSuffecientlyLong])
         {
-            [self removeKVOObserver];
             [self.navBarController expand];
-            [self addKVOObserver];
         }
     }
     else
     {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
     }
-}
-
-- (void)addKVOObserver
-{
-    [_scrollView addObserver:self forKeyPath:@"contentSize" options:0 context:kTLYShyNavBarManagerKVOContext];
-}
-
-- (void)removeKVOObserver
-{
-    [_scrollView removeObserver:self forKeyPath:@"contentSize" context:kTLYShyNavBarManagerKVOContext];
 }
 
 #pragma mark - public methods

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -196,16 +196,16 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
     }
 }
 
-- (void)setHasCustomRefreshController:(BOOL)hasCustomRefreshController
+- (void)setHasCustomRefreshControl:(BOOL)hasCustomRefreshControl
 {
-    if (_hasCustomRefreshController == hasCustomRefreshController)
+    if (_hasCustomRefreshControl == hasCustomRefreshControl)
     {
         return;
     }
     
-    _hasCustomRefreshController = hasCustomRefreshController;
+    _hasCustomRefreshControl = hasCustomRefreshControl;
     
-    self.scrollViewController.hasCustomRefreshController = hasCustomRefreshController;
+    self.scrollViewController.hasCustomRefreshControl = hasCustomRefreshControl;
 }
 
 - (BOOL)stickyNavigationBar

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -112,7 +112,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
     }
 
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [_scrollView removeObserver:self forKeyPath:@"contentSize" context:kTLYShyNavBarManagerKVOContext];
+    [self removeKVOObserver];
 }
 
 #pragma mark - Properties
@@ -142,7 +142,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
 
 - (void)setScrollView:(UIScrollView *)scrollView
 {
-    [_scrollView removeObserver:self forKeyPath:@"contentSize" context:kTLYShyNavBarManagerKVOContext];
+    [self removeKVOObserver];
 
     if (_scrollView.delegate == self.delegateProxy)
     {
@@ -169,7 +169,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
     [self cleanup];
     [self layoutViews];
 
-    [_scrollView addObserver:self forKeyPath:@"contentSize" options:0 context:kTLYShyNavBarManagerKVOContext];
+    [self addKVOObserver];
 }
 
 - (CGRect)extensionViewBounds
@@ -359,13 +359,25 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
     {
         if (self.isViewControllerVisible && ![self _scrollViewIsSuffecientlyLong])
         {
+            [self removeKVOObserver];
             [self.navBarController expand];
+            [self addKVOObserver];
         }
     }
     else
     {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
     }
+}
+
+- (void)addKVOObserver
+{
+    [_scrollView addObserver:self forKeyPath:@"contentSize" options:0 context:kTLYShyNavBarManagerKVOContext];
+}
+
+- (void)removeKVOObserver
+{
+    [_scrollView removeObserver:self forKeyPath:@"contentSize" context:kTLYShyNavBarManagerKVOContext];
 }
 
 #pragma mark - public methods


### PR DESCRIPTION
This just handles a common scenario of using a custom pull to refresh control like `SVPullToRefresh`.
It also fixes #133, and I haven't checked by it will probably solve also #99 because as I see it, the problem there is using `UIRefreshControl` not in a `UITableViewController` which is kinda custom pull to refresh control. 
It fixed my issues with `SVPullToRefresh`(flickering, crashing and some more bugs) so I guess it will be helpful to some more.

usage:
```
self.shyNavBarManager.hasCustomRefreshControl = YES;
```

:)