### PR TITLE
Added fast forwarding to TLYDelegateProxy

### DIFF
--- a/TLYShyNavBar/Categories/TLYDelegateProxy.m
+++ b/TLYShyNavBar/Categories/TLYDelegateProxy.m
@@ -26,6 +26,20 @@
     return self;
 }
 
+- (id)forwardingTargetForSelector:(SEL)sel
+{
+    BOOL originalDelegateResponds = [self.originalDelegate respondsToSelector:sel];
+    BOOL middleManResponds = [self.middleMan respondsToSelector:sel];
+    if (originalDelegateResponds && !middleManResponds) {
+        return self.originalDelegate;
+    } else if (!originalDelegateResponds && middleManResponds) {
+        return self.middleMan;
+    } else {
+        // continue with "slow" forwarding
+        return self;
+    }
+}
+
 - (NSInvocation *)_copyInvocation:(NSInvocation *)invocation
 {
     NSInvocation *copy = [NSInvocation invocationWithMethodSignature:[invocation methodSignature]];


### PR DESCRIPTION
When there is only a single object implementing a given selector in `TLYDelegateProxy`, fast forwarding is possible. That prevents the 'slow' forwarding mechanism from getting triggered, which involves the use of `NSInvocation`.
In the original implementation, when scrolling through a lot of cells in a `UITableView`, I was able to measure a relatively high amount of time being spent in the 'slow' forwarding mechanism, in the main thread.