### PR TITLE
Expand navBar if scrollView's window is visible

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -445,7 +445,9 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification
 {
-    [self.navBarController expand];
+    if (self.scrollView.window) {
+        [self.navBarController expand];
+    }
 }
 
 - (void)applicationDidChangeStatusBarFrame:(NSNotification *)notification


### PR DESCRIPTION
Fixes an issue when the navigation bar is manually hidden in another UIViewController in the stack. This PR makes sure that when the app becomes active it will only expand the navBar if the current scrollView is visible on the window.