### PR TITLE
fix delegate calling

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -339,7 +339,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
         return;
     }
 
-    __weak __typeof(self) weakSelf;
+    __weak __typeof(self) weakSelf = self;
     void (^completion)() = ^
     {
         __typeof(self) strongSelf = weakSelf;


### PR DESCRIPTION
I find error in delegate calling as result delegate methods not calling.

The problem was in initialization weak link on object.

__weak __typeof(self) weakSelf; => __weak __typeof(self) weakSelf = self;