### PR TITLE
Fix appearance when presented in a popover.  

### DIFF
--- a/TLYShyNavBar/ShyControllers/TLYShyStatusBarController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyStatusBarController.m
@@ -20,6 +20,11 @@ static inline CGFloat AACStatusBarHeight(UIViewController *viewController)
     }
     
     // Modal views do not overlap the status bar, so no allowance need be made for it
+    if (viewController.presentingViewController != nil)
+    {
+        return 0.f;
+    }
+
     CGSize  statusBarSize = [UIApplication sharedApplication].statusBarFrame.size;
     CGFloat statusBarHeight = MIN(statusBarSize.width, statusBarSize.height);
     

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -27,7 +27,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
 
 @interface TLYShyNavBarManager () <UIScrollViewDelegate>
 
-@property (nonatomic, strong) id<TLYShyParent> statusBarController;
+@property (nonatomic, strong) TLYShyStatusBarController *statusBarController;
 @property (nonatomic, strong) TLYShyViewController *navBarController;
 @property (nonatomic, strong) TLYShyViewController *extensionController;
 @property (nonatomic, strong) TLYShyScrollViewController *scrollViewController;
@@ -137,6 +137,8 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
 
     self.navBarController.view = navbar;
 
+    self.statusBarController.viewController = viewController;
+    
     [self layoutViews];
 }
 


### PR DESCRIPTION
This reapplies a change from 2015 which was lost in the refactor to treat status bar height as 0 if in a presenting view controller, and also passes the viewController on to the statusBarController so that it can be used to determine whether that's needed.