### PR TITLE
Rolled back changes regarding displaying the the extended nav bar in a modal

### DIFF
--- a/TLYShyNavBar/ShyControllers/TLYShyStatusBarController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyStatusBarController.m
@@ -20,11 +20,6 @@ static inline CGFloat AACStatusBarHeight(UIViewController *viewController)
     }
     
     // Modal views do not overlap the status bar, so no allowance need be made for it
-    if (viewController.presentingViewController != nil)
-    {
-        return 0.f;
-    }
-
     CGSize  statusBarSize = [UIApplication sharedApplication].statusBarFrame.size;
     CGFloat statusBarHeight = MIN(statusBarSize.width, statusBarSize.height);
     

--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -27,7 +27,7 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
 
 @interface TLYShyNavBarManager () <UIScrollViewDelegate>
 
-@property (nonatomic, strong) TLYShyStatusBarController *statusBarController;
+@property (nonatomic, strong) id<TLYShyParent> statusBarController;
 @property (nonatomic, strong) TLYShyViewController *navBarController;
 @property (nonatomic, strong) TLYShyViewController *extensionController;
 @property (nonatomic, strong) TLYShyScrollViewController *scrollViewController;
@@ -137,8 +137,6 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
 
     self.navBarController.view = navbar;
 
-    self.statusBarController.viewController = viewController;
-    
     [self layoutViews];
 }
 


### PR DESCRIPTION
This is really up for discussion.
In an app I'm developing, this fixes an issue where the nav bar goes up exactly the height of the status bar.
I rolled back 80d54579b88b99548fd531b849f6a13286dea3e0, apparently that fixed a bug, I'm not sure, but that commit was exactly what broke the layout in the app I'm working on.

![captura de pantalla 2017-01-26 a las 20 50 05](https://cloud.githubusercontent.com/assets/1040182/22355436/4c9d7804-e409-11e6-926f-600b6217a330.png)
