### PR TITLE
Fix navigation bar expanding when it shouldn't

### DIFF
--- a/TLYShyNavBar/TLYShyNavBarManager.m
+++ b/TLYShyNavBar/TLYShyNavBarManager.m
@@ -416,7 +416,8 @@ static void * const kTLYShyNavBarManagerKVOContext = (void*)&kTLYShyNavBarManage
 
 - (void)layoutViews
 {
-    if (fabs([self.scrollViewController updateLayoutIfNeeded]) > FLT_EPSILON)
+    if (fabs([self.scrollViewController updateLayoutIfNeeded]) > FLT_EPSILON
+            && self.scrollView.contentOffset.y != self.previousYOffset)
     {
         [self.navBarController expand];
         [self.extensionViewContainer.superview bringSubviewToFront:self.extensionViewContainer];


### PR DESCRIPTION
This would happen any time you reload the data of your `table` or `collection`, i.e, loading more data when scrolling, reloading to change the design of the cells, etc.

This might be related to #120.